### PR TITLE
Using RwLock.

### DIFF
--- a/tests/basic_test.rs
+++ b/tests/basic_test.rs
@@ -3,20 +3,20 @@ use pancake::storage::lsm;
 use rand;
 use std::collections::BTreeMap;
 
-fn put(s: &mut lsm::LSM, k: &String, v: Option<String>) {
+fn put(lsm: &mut lsm::LSM, k: &String, v: Option<String>) {
     let v = match v {
         None => Value::Tombstone,
         Some(v) => Value::Bytes(v.as_bytes().to_vec()),
     };
-    s.put(Key(k.clone()), v).unwrap();
+    lsm.put(Key(k.clone()), v).unwrap();
 }
 
-fn get(s: &mut lsm::LSM, k: String) -> Option<Value> {
-    s.get(Key(k)).unwrap()
+fn get(lsm: &mut lsm::LSM, k: String) -> Option<Value> {
+    lsm.get(Key(k)).unwrap()
 }
 
-fn get_print(s: &mut lsm::LSM, k: String, exp_deleted: bool) {
-    match get(s, k.clone()) {
+fn test_get(lsm: &mut lsm::LSM, k: String, exp_deleted: bool) {
+    match get(lsm, k.clone()) {
         None | Some(Value::Tombstone) => {
             println!("{} ... No such key", k);
             assert!(exp_deleted);
@@ -30,27 +30,29 @@ fn get_print(s: &mut lsm::LSM, k: String, exp_deleted: bool) {
 
 #[test]
 fn random_data() {
-    let mut s = lsm::LSM::init().unwrap();
+    let mut lsm = lsm::LSM::init().unwrap();
 
     let mut i_to_deleted = BTreeMap::new();
 
-    for _ in 0..37 {
+    for _ in 0..600 {
         let i = rand::random::<u8>();
 
         let key = format!("key{}", i);
         let val = Some(format!("val{}", i));
 
-        put(&mut s, &key, val);
+        put(&mut lsm, &key, val);
 
         let is_deleted = rand::random::<f32>() < 0.3;
         if is_deleted {
-            put(&mut s, &key, None);
+            put(&mut lsm, &key, None);
             println!("key {} is del.", i);
         }
         i_to_deleted.insert(i, is_deleted);
     }
 
     for (i, is_deleted) in i_to_deleted.iter() {
-        get_print(&mut s, format!("key{}", i), *is_deleted);
+        test_get(&mut lsm, format!("key{}", i), *is_deleted);
     }
+
+    test_get(&mut lsm, String::from("nonexistent"), true);
 }


### PR DESCRIPTION
This is a draft PR that shows how I think mutual exclusion of a background job might look like.

I'm still not sure how to actually make the task run concurrently. (In c++ I'm familiar with the pattern of a class owning a thread and its destructor joining or detaching it, but in rust we need to convince the compiler that `self`'s lifetime exceeds task's lifetime.)

There are two locks within the LSM struct. There should be no deadlock b/c the "flow" of data is unidirectional: head to sstables. Tasks can always 1) update the "downstream" sstables, then 2) update the "upstream" head. We could also ensure all takss lock 1) head 2) sstables in that order. Or we could wrap the whole LSM struct in a RwLock; intuitively I believe this last option is less performant, but who knows until we test it out...