### PR TITLE
Fix SparseIndex

### DIFF
--- a/src/storage/sstable.rs
+++ b/src/storage/sstable.rs
@@ -192,10 +192,14 @@ impl SparseIndex {
 
     fn nearest_preceding_file_offset(&self, key: &Key) -> FileOffset {
         // TODO what's the best way to bisect a BTreeMap? this appears to have O(n) cost
-        let idx_pos = self.map.iter().rposition(|kv| kv.0 <= key).unwrap_or(0u64);
-
+        let idx_pos = self.map.iter().rposition(|kv| kv.0 <= key);
+        match idx_pos {
+            None => 0u64,
+            Some(idx_pos) => {
+                let (_, file_offset) = self.map.iter().nth(idx_pos).unwrap();
+                *file_offset
+            }
+        }
         // TODO/FIXME: iter().nth appears to incur a O(n) cost
-        let (_, file_offset) = self.map.iter().nth(idx_pos).unwrap();
-        return *file_offset;
     }
 }

--- a/tests/basic_test.rs
+++ b/tests/basic_test.rs
@@ -8,7 +8,7 @@ use std::env::temp_dir;
 
 #[test]
 fn test_in_single_thread() -> Result<()> {
-    let dir = temp_dir();
+    let dir = temp_dir().join("pancake");
     let mut lsm = lsm::LSM::open(dir)?;
 
     put_then_tomb(&mut lsm)?;


### PR DESCRIPTION
Sorry I must have merged https://github.com/ysono/pancake/pull/37 before it was finalized. It wasn't compiling, and also the logic was restored.

First we bisect in-memory structure (now TreeMap, soon to be Vector), in order to find the file offset.

Then we go to the file offset.

The code was mixing up the position of iterator on the in-memory structure with the file offset.