### PR TITLE
Pure refactor in anticipation of secondary index

### DIFF
--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -1,5 +1,5 @@
 use crate::storage::api::{Datum, Key, Value};
-use crate::storage::LSM;
+use crate::storage::db::DB;
 use anyhow::{anyhow, Error, Result};
 use futures::executor::block_on;
 use hyper::{Body, Request, Response, Server, StatusCode};
@@ -7,6 +7,7 @@ use routerify::prelude::*;
 use routerify::{Middleware, RequestInfo, Router, RouterService};
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock};
+use std::env;
 
 async fn logger(req: Request<Body>) -> Result<Request<Body>> {
     println!(
@@ -22,10 +23,10 @@ async fn get_handler(req: Request<Body>) -> Result<Response<Body>> {
     let key: &String = req.param("key").unwrap();
     let key = Key(Datum::Str(key.clone()));
 
-    let lsm = req.data::<Arc<RwLock<LSM>>>().unwrap();
-    let lsm = lsm.read().unwrap();
+    let db = req.data::<Arc<RwLock<DB>>>().unwrap();
+    let db = db.read().unwrap();
 
-    let val: Value = lsm.get(key)?;
+    let val: Value = db.get(key)?;
 
     match val.0 {
         None => Response::builder()
@@ -53,10 +54,10 @@ async fn put_handler(req: Request<Body>) -> Result<Response<Body>> {
     let val: Vec<u8> = block_on(hyper::body::to_bytes(body))?.to_vec();
     let val = Value::from(Datum::Bytes(val));
 
-    let lsm = parts.data::<Arc<RwLock<LSM>>>().unwrap();
-    let mut lsm = lsm.write().unwrap();
+    let db = parts.data::<Arc<RwLock<DB>>>().unwrap();
+    let mut db = db.write().unwrap();
 
-    lsm.put(key, val)?;
+    db.put(key, val)?;
 
     Response::builder()
         .status(StatusCode::NO_CONTENT)
@@ -68,10 +69,10 @@ async fn delete_handler(req: Request<Body>) -> Result<Response<Body>> {
     let key: &String = req.param("key").unwrap();
     let key = Key(Datum::Str(key.clone()));
 
-    let lsm = req.data::<Arc<RwLock<LSM>>>().unwrap();
-    let mut lsm = lsm.write().unwrap();
+    let db = req.data::<Arc<RwLock<DB>>>().unwrap();
+    let mut db = db.write().unwrap();
 
-    lsm.put(key, Value(None))?;
+    db.put(key, Value(None))?;
 
     Response::builder()
         .status(StatusCode::NO_CONTENT)
@@ -88,11 +89,12 @@ async fn error_handler(err: routerify::RouteError, _: RequestInfo) -> Response<B
 }
 
 fn router() -> Router<Body, Error> {
-    let path = "/tmp/pancake";
-    let lsm: Arc<RwLock<LSM>> = Arc::new(RwLock::new(LSM::open(path).unwrap()));
+    let path = env::temp_dir().join("pancake");
+    let db = DB::open(path).unwrap();
+    let db: Arc<RwLock<DB>> = Arc::new(RwLock::new(db));
 
     Router::builder()
-        .data(lsm)
+        .data(db)
         .middleware(Middleware::pre(logger))
         .get("/key/:key", get_handler)
         .put("/key/:key", put_handler)

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -1,0 +1,28 @@
+use crate::storage::api::{Key, Value};
+use crate::storage::lsm::LSMTree;
+use anyhow::Result;
+use std::path::Path;
+
+const PRIMARY_INDEX: &'static str = "primary_index";
+
+pub struct DB {
+    primary_index: LSMTree,
+}
+
+impl DB {
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<DB> {
+        let primary_index = LSMTree::open(path.as_ref().join(PRIMARY_INDEX))?;
+
+        let db = DB { primary_index };
+
+        Ok(db)
+    }
+
+    pub fn put(&mut self, k: Key, v: Value) -> Result<()> {
+        self.primary_index.put(k, v)
+    }
+
+    pub fn get(&self, k: Key) -> Result<Value> {
+        self.primary_index.get(k)
+    }
+}

--- a/src/storage/lsm.rs
+++ b/src/storage/lsm.rs
@@ -34,7 +34,7 @@ impl Memtable {
     }
 }
 
-pub struct LSM {
+pub struct LSMTree {
     path: PathBuf,
     memtable: Memtable,
     commit_log_path: PathBuf,
@@ -43,8 +43,8 @@ pub struct LSM {
     sstables: Vec<SSTable>,
 }
 
-impl LSM {
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<LSM> {
+impl LSMTree {
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<LSMTree> {
         std::fs::create_dir_all(path.as_ref().join(COMMIT_LOGS_DIR_PATH))?;
         std::fs::create_dir_all(path.as_ref().join(SSTABLES_DIR_PATH))?;
 
@@ -71,7 +71,7 @@ impl LSM {
                 .collect();
         let sstables = sstables?;
 
-        let ret = LSM {
+        let ret = LSMTree {
             path: path.as_ref().into(),
             memtable,
             commit_log_path,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,7 +1,6 @@
 pub mod api;
+pub mod db;
 pub mod lsm;
 pub mod serde;
 pub mod sstable;
 pub mod utils;
-
-pub use lsm::LSM;


### PR DESCRIPTION
This adds a "DB" abstraction on top of LSMTree. Secondary index will go under DB.

There is no change in behavior. Tests pass.

I wanted to get this in in order to reduce file conflicts.