### PR TITLE
generic sstable

### DIFF
--- a/src/frontend/http.rs
+++ b/src/frontend/http.rs
@@ -1,5 +1,5 @@
-use crate::storage::api::Datum;
 use crate::storage::db::DB;
+use crate::storage::types::Datum;
 use anyhow::{anyhow, Error, Result};
 use futures::executor::block_on;
 use hyper::{Body, Request, Response, Server, StatusCode};

--- a/src/storage/api.rs
+++ b/src/storage/api.rs
@@ -7,9 +7,3 @@ pub enum Datum {
     Str(String),
     Tuple(Vec<Datum>),
 }
-
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
-pub enum OptDatum {
-    Tombstone,
-    Some(Datum),
-}

--- a/src/storage/api.rs
+++ b/src/storage/api.rs
@@ -1,9 +1,1 @@
-use std::cmp::{Eq, Ord, PartialEq, PartialOrd};
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
-pub enum Datum {
-    Bytes(Vec<u8>),
-    I64(i64),
-    Str(String),
-    Tuple(Vec<Datum>),
-}

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -1,12 +1,13 @@
 use crate::storage::api::Datum;
 use crate::storage::lsm::LSMTree;
+use crate::storage::serde::OptDatum;
 use anyhow::Result;
 use std::path::Path;
 
 const PRIMARY_INDEX: &'static str = "primary_index";
 
 pub struct DB {
-    primary_index: LSMTree,
+    primary_index: LSMTree<Datum, OptDatum<Datum>>,
 }
 
 impl DB {
@@ -19,14 +20,17 @@ impl DB {
     }
 
     pub fn put(&mut self, k: Datum, v: Datum) -> Result<()> {
-        self.primary_index.put(k, v)
-    }
-
-    pub fn get(&self, k: Datum) -> Result<Option<Datum>> {
-        self.primary_index.get(k)
+        self.primary_index.put(k, OptDatum::Some(v))
     }
 
     pub fn delete(&mut self, k: Datum) -> Result<()> {
-        self.primary_index.delete(k)
+        self.primary_index.put(k, OptDatum::Tombstone)
+    }
+
+    pub fn get(&self, k: Datum) -> Result<Option<Datum>> {
+        match self.primary_index.get(k)? {
+            Some(OptDatum::Some(dat)) => Ok(Some(dat)),
+            _ => Ok(None),
+        }
     }
 }

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -1,6 +1,5 @@
-use crate::storage::api::Datum;
 use crate::storage::lsm::LSMTree;
-use crate::storage::serde::OptDatum;
+use crate::storage::types::{Datum, OptDatum};
 use anyhow::Result;
 use std::path::Path;
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3,4 +3,5 @@ pub mod db;
 pub mod lsm;
 pub mod serde;
 pub mod sstable;
+pub mod types;
 pub mod utils;

--- a/src/storage/serde.rs
+++ b/src/storage/serde.rs
@@ -48,7 +48,7 @@
 //! }
 //! ```
 
-use super::api::{Datum, OptDatum};
+use super::api::Datum;
 use anyhow::{anyhow, Result};
 use derive_more::From;
 use num_derive::{FromPrimitive, ToPrimitive};
@@ -56,6 +56,12 @@ use num_traits::FromPrimitive;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::mem::size_of;
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
+pub enum OptDatum {
+    Tombstone,
+    Some(Datum),
+}
 
 /*
 We manually map enum members to data_type integers because:

--- a/src/storage/sstable.rs
+++ b/src/storage/sstable.rs
@@ -1,10 +1,9 @@
-use crate::storage::api::{Datum, OptDatum};
-use crate::storage::lsm::Memtable;
-use crate::storage::serde::{self, KeyValueIterator, ReadItem, SkipItem};
+use crate::storage::serde::{self, KeyValueIterator, ReadItem, Serializable, SkipItem};
 use anyhow::{anyhow, Result};
 use core::option::Option;
 use core::option::Option::{None, Some};
 use core::result::Result::Ok;
+use derive_more::{Deref, DerefMut};
 use itertools::Itertools;
 use std::collections::BTreeMap;
 use std::fs;
@@ -17,47 +16,50 @@ type FileOffset = u64;
 
 static SSTABLE_IDX_SPARSENESS: usize = 3;
 
-/// One SS Table. It consists of a file on disk and an in-memory sparse indexing of the file.
-#[derive(Debug)]
-pub struct SSTable {
-    path: PathBuf,
-    sparse_index: SparseIndex,
+fn is_kv_sparsely_captured(kv_i: usize) -> bool {
+    kv_i % SSTABLE_IDX_SPARSENESS == SSTABLE_IDX_SPARSENESS - 1
 }
 
-impl SSTable {
-    fn is_kv_in_mem(kv_i: usize) -> bool {
-        kv_i % SSTABLE_IDX_SPARSENESS == SSTABLE_IDX_SPARSENESS - 1
-    }
+/// One SS Table. It consists of a file on disk and an in-memory sparse indexing of the file.
+#[derive(Debug)]
+pub struct SSTable<K: Serializable + Ord + Clone> {
+    path: PathBuf,
+    sparse_index: SparseIndex<K>,
+}
 
-    pub fn write_from_memtable(memtable: &Memtable, path: PathBuf) -> Result<SSTable> {
-        let mut sparse_index = SparseIndex::new();
+impl<K: Serializable + Ord + Clone> SSTable<K> {
+    pub fn write_from_mem<V>(mem: &BTreeMap<K, V>, path: PathBuf) -> Result<SSTable<K>>
+    where
+        V: Serializable,
+    {
+        let mut sparse_index = SparseIndex::<K>::new();
         let mut file = OpenOptions::new()
             .create(true)
             .write(true)
             .truncate(true)
             .open(&path)?;
         let mut offset = 0usize;
-        for (kv_i, (k, v)) in memtable.iter().enumerate() {
+        for (kv_i, (k, v)) in mem.iter().enumerate() {
             let delta_offset = serde::serialize_kv(k, v, &mut file)?;
 
-            if SSTable::is_kv_in_mem(kv_i) {
+            if is_kv_sparsely_captured(kv_i) {
                 sparse_index.insert((*k).clone(), offset as FileOffset);
             }
 
             offset += delta_offset;
         }
 
-        Ok(SSTable { path, sparse_index })
+        Ok(SSTable::<K> { path, sparse_index })
     }
 
-    pub fn read_from_file(path: PathBuf) -> Result<SSTable> {
-        let mut sparse_index = SparseIndex::new();
+    pub fn read_from_file(path: PathBuf) -> Result<SSTable<K>> {
+        let mut sparse_index = SparseIndex::<K>::new();
         let mut file = File::open(&path)?;
         let mut offset = 0usize;
         for kv_i in 0usize.. {
             // Key
-            if SSTable::is_kv_in_mem(kv_i) {
-                match serde::read_item::<Datum>(&mut file)? {
+            if is_kv_sparsely_captured(kv_i) {
+                match serde::read_item::<K>(&mut file)? {
                     ReadItem::EOF => break,
                     ReadItem::Some { read_size, obj } => {
                         sparse_index.insert(obj, offset as FileOffset);
@@ -82,7 +84,7 @@ impl SSTable {
             }
         }
 
-        Ok(SSTable { path, sparse_index })
+        Ok(SSTable::<K> { path, sparse_index })
     }
 
     /// Both the in-memory index and the file are sorted by key.
@@ -92,10 +94,11 @@ impl SSTable {
     ///
     /// @return
     ///     `None` if not found within this sstable.
-    ///     `Some(_)` if found.
-    ///     `Some(OptDatum::Tombstone)` if found and value is tombstone.
-    ///     `Some(OptDatum::Some(_))` if found and value is non-tombstone.
-    pub fn get(&self, k: &Datum) -> Result<Option<OptDatum>> {
+    ///     `Some(_: V)` if found.
+    pub fn get<V>(&self, k: &K) -> Result<Option<V>>
+    where
+        V: Serializable,
+    {
         let file_offset = self.sparse_index.nearest_preceding_file_offset(k);
 
         let mut file = File::open(&self.path)?;
@@ -103,14 +106,14 @@ impl SSTable {
 
         loop {
             // Key
-            let found = match serde::read_item::<Datum>(&mut file)? {
+            let found = match serde::read_item::<K>(&mut file)? {
                 ReadItem::EOF => break,
                 ReadItem::Some { read_size: _, obj } => &obj == k,
             };
 
             // Value
             if found {
-                match serde::read_item::<OptDatum>(&mut file)? {
+                match serde::read_item::<V>(&mut file)? {
                     ReadItem::EOF => return Err(anyhow!("Unexpected EOF while reading a value.")),
                     ReadItem::Some { read_size: _, obj } => return Ok(Some(obj)),
                 }
@@ -126,10 +129,7 @@ impl SSTable {
         Ok(())
     }
 
-    pub fn compact<'a, I: Iterator<Item = &'a Self>>(
-        path: PathBuf,
-        tables: I,
-    ) -> Result<Vec<Self>> {
+    pub fn compact(path: PathBuf, tables: &Vec<Self>) -> Result<Vec<Self>> {
         let mut file = OpenOptions::new()
             .create_new(true)
             .write(true)
@@ -198,24 +198,20 @@ impl SSTable {
     }
 }
 
-#[derive(Debug)]
-struct SparseIndex {
+#[derive(Deref, DerefMut, Debug)]
+struct SparseIndex<K: Serializable + Ord> {
     // this version of the index is backed by an ordered map.
-    map: BTreeMap<Datum, FileOffset>,
+    map: BTreeMap<K, FileOffset>,
 }
 
-impl SparseIndex {
+impl<K: Serializable + Ord> SparseIndex<K> {
     fn new() -> Self {
         Self {
             map: Default::default(),
         }
     }
 
-    fn insert(&mut self, key: Datum, offset: FileOffset) {
-        self.map.insert(key, offset);
-    }
-
-    fn nearest_preceding_file_offset(&self, key: &Datum) -> FileOffset {
+    fn nearest_preceding_file_offset(&self, key: &K) -> FileOffset {
         // TODO what's the best way to bisect a BTreeMap? this appears to have O(n) cost
         let idx_pos = self.map.iter().rposition(|kv| kv.0 <= key);
         match idx_pos {

--- a/src/storage/types/datum.rs
+++ b/src/storage/types/datum.rs
@@ -1,0 +1,104 @@
+use crate::storage::serde::{self, DatumType, ReadItem, Serializable};
+use anyhow::{anyhow, Result};
+use std::cmp::{Eq, Ord, PartialEq, PartialOrd};
+use std::fs::File;
+use std::io::{Read, Write};
+use std::mem;
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
+pub enum Datum {
+    Bytes(Vec<u8>),
+    I64(i64),
+    Str(String),
+    Tuple(Vec<Datum>),
+}
+
+#[derive(Clone)]
+pub enum OptDatum<T: Serializable> {
+    Tombstone,
+    Some(T),
+}
+
+impl Serializable for Datum {
+    fn ser(&self, w: &mut impl Write) -> Result<usize> {
+        let write_size: usize = match self {
+            Datum::Bytes(b) => serde::write_item(DatumType::Bytes, b, w)?,
+            Datum::I64(i) => serde::write_item(DatumType::I64, &i.to_le_bytes(), w)?,
+            Datum::Str(s) => serde::write_item(DatumType::Str, s.as_bytes(), w)?,
+            Datum::Tuple(vec) => {
+                let mut b: Vec<u8> = vec![];
+
+                b.write(&vec.len().to_le_bytes())?;
+
+                for dat in vec.iter() {
+                    dat.ser(&mut b)?;
+                }
+
+                serde::write_item(DatumType::Tuple, &b, w)?
+            }
+        };
+        Ok(write_size)
+    }
+
+    fn deser(datum_size: usize, datum_type: DatumType, r: &mut File) -> Result<Self> {
+        let obj: Self = match datum_type {
+            DatumType::Bytes => {
+                let mut buf = vec![0u8; datum_size];
+                r.read_exact(&mut buf)?;
+                Datum::Bytes(buf)
+            }
+            DatumType::I64 => {
+                let mut buf = [0u8; mem::size_of::<i64>()];
+                r.read_exact(&mut buf)?;
+                Datum::I64(i64::from_le_bytes(buf))
+            }
+            DatumType::Str => {
+                let mut buf = vec![0u8; datum_size];
+                r.read_exact(&mut buf)?;
+                Datum::Str(String::from_utf8(buf)?)
+            }
+            DatumType::Tuple => {
+                let mut tup_len_buf = [0u8; mem::size_of::<usize>()];
+                r.read_exact(&mut tup_len_buf)?;
+                let tup_len = usize::from_le_bytes(tup_len_buf);
+
+                let mut members = Vec::<Datum>::with_capacity(tup_len);
+
+                for _ in 0..tup_len {
+                    match serde::read_item(r)? {
+                        ReadItem::EOF => {
+                            return Err(anyhow!("Unexpected EOF while reading a tuple."))
+                        }
+                        ReadItem::Some { read_size: _, obj } => {
+                            members.push(obj);
+                        }
+                    }
+                }
+
+                Datum::Tuple(members)
+            }
+            _ => return Err(anyhow!("Unexpected datum_type {:?}", datum_type)),
+        };
+        Ok(obj)
+    }
+}
+
+impl<T: Serializable> Serializable for OptDatum<T> {
+    fn ser(&self, w: &mut impl Write) -> Result<usize> {
+        match self {
+            OptDatum::Tombstone => serde::write_item(DatumType::Tombstone, &[0u8; 0], w),
+            OptDatum::Some(dat) => dat.ser(w),
+        }
+    }
+
+    fn deser(datum_size: usize, datum_type: DatumType, r: &mut File) -> Result<Self> {
+        let obj: Self = match datum_type {
+            DatumType::Tombstone => OptDatum::Tombstone,
+            _ => {
+                let dat = T::deser(datum_size, datum_type, r)?;
+                OptDatum::Some(dat)
+            }
+        };
+        Ok(obj)
+    }
+}

--- a/src/storage/types/mod.rs
+++ b/src/storage/types/mod.rs
@@ -1,0 +1,3 @@
+mod datum;
+
+pub use datum::*;

--- a/tests/basic_test.rs
+++ b/tests/basic_test.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use pancake::storage::api::Datum;
 use pancake::storage::db::DB;
+use pancake::storage::types::Datum;
 use rand;
 use std::collections::BTreeMap;
 use std::env::temp_dir;


### PR DESCRIPTION
1. Make struct SSTable generic.

The main motivation is secondary index.

Primary
- File stores (Datum, OptDatum) tuples.
- In-mem map stores {Datum: offset_in_primary_sstable_file}

Secondary
- File stores (SubDatum, primary_sstable_file_and_offset_therein) tuples.
- In-mem map stores {SubDatum: offset_in_secondary_sstable_file}

2. Make OptDatum more private.

OptDatum has become a concept internal to LSMTree only. I tried to make `struct OptDatum` private within `lsm.rs`, but the struct is tightly tied in with other code in `serde.rs`.